### PR TITLE
Update engines in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,8 +29,8 @@
   },
   "homepage": "https://github.com/suiteplus/nsmockup#readme",
   "engines": {
-    "node": "4.0.0",
-    "npm": "2.10.0"
+    "npm": "~3.10.9",
+    "node": "~6.9.1"
   },
   "dependencies": {
     "body-parser": "1.18.2",


### PR DESCRIPTION
Bump up engines to more up-to-date npm and node versions so yarn doesn't block it due to its strict policy.